### PR TITLE
API: Add validation for keyword count in upload file

### DIFF
--- a/api/modules/file/file.service.js
+++ b/api/modules/file/file.service.js
@@ -44,12 +44,14 @@ class FileService {
 
   async extractKeywordsFromCSV({ filePath, userId, fileId }) {
     const csvRows = await this.parseCSVFile(filePath);
-    if (csvRows.length > 100) {
-      throw new Error('Uploaded file has more than 100 keywords');
-    }
     if (!csvRows.length) {
       throw new Error('No keywords found in File. Ensure to have data under a column with header "Keyword"');
     }
+
+    if (csvRows.length > 100) {
+      throw new Error('Uploaded file has more than 100 keywords');
+    }
+
     const uniqueKeywords = [...new Set(csvRows)];
 
     const keywordRecords = uniqueKeywords.map(keyword => {

--- a/api/modules/file/file.service.js
+++ b/api/modules/file/file.service.js
@@ -47,6 +47,9 @@ class FileService {
     if (csvRows.length > 100) {
       throw new Error('Uploaded file has more than 100 keywords');
     }
+    if (!csvRows.length) {
+      throw new Error('No keywords found in File. Ensure to have data under a column with header "Keyword"');
+    }
     const uniqueKeywords = [...new Set(csvRows)];
 
     const keywordRecords = uniqueKeywords.map(keyword => {

--- a/api/tests/file-upload.test.js
+++ b/api/tests/file-upload.test.js
@@ -6,43 +6,46 @@ chai.use(chaiAsPromised);
 
 import fileService from '../modules/file/file.service.js';
 
-describe('extractKeywordsFromCSV Tests', function() {
-    let __dirname = path.dirname(fileURLToPath(import.meta.url));
+describe('extractKeywordsFromCSV Tests', function () {
+  let __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-  beforeEach(function() {
-  });
+  beforeEach(function () {});
 
-  it('should handle files with less than 100 keywords', async function() {
+  it('should handle files with less than 100 keywords', async function () {
     const filePath = path.join(__dirname, 'fixtures', 'csv', 'keywords_10.csv');
     const result = await fileService.extractKeywordsFromCSV({ filePath, userId: 1, fileId: 1 });
-    const allItemsValid = result.every(item => 
-        item.name && 
-        item.fileId && 
-        item.userId &&
-        item.fileId === 1 &&
-        item.userId === 1
-      );
+    const allItemsValid = result.every(
+      item => item.name && item.fileId && item.userId && item.fileId === 1 && item.userId === 1
+    );
     chai.expect(result).to.be.an('array').that.has.lengthOf(10);
     chai.expect(allItemsValid).to.be.true;
-
   });
 
-  it('should throw an error for files with more than 100 keywords', async function() {
-    const filePath = path.join(__dirname, 'fixtures', 'csv',  'keywords_200.csv');
-    
-    await chai.expect(fileService.extractKeywordsFromCSV({ filePath, userId: 1, fileId: 1 }))
+  it('should throw an error for files with more than 100 keywords', async function () {
+    const filePath = path.join(__dirname, 'fixtures', 'csv', 'keywords_200.csv');
+
+    await chai
+      .expect(fileService.extractKeywordsFromCSV({ filePath, userId: 1, fileId: 1 }))
       .to.eventually.be.rejectedWith('Uploaded file has more than 100 keywords');
   });
 
-  it('should have no duplicate keywords', async function() {
-    const filePath = path.join(__dirname, 'fixtures', 'csv', 'keywords_duplicate.csv'); 
+  it('should have no duplicate keywords', async function () {
+    const filePath = path.join(__dirname, 'fixtures', 'csv', 'keywords_duplicate.csv');
     const response = await fileService.extractKeywordsFromCSV({ filePath, userId: 1, fileId: 1 });
-  
+
     const keywords = response.map(item => item.name);
-  
+
     const uniqueKeywordsSet = new Set(keywords);
-  
+
     chai.expect(uniqueKeywordsSet.size).to.equal(keywords.length);
   });
 
+  it('should throw an error for files with wrong header', async function () {
+    const filePath = path.join(__dirname, 'fixtures', 'csv', 'keywords_wrong_header.csv');
+    await chai
+      .expect(fileService.extractKeywordsFromCSV({ filePath, userId: 1, fileId: 1 }))
+      .to.eventually.be.rejectedWith(
+        'No keywords found in File. Ensure to have data under a column with header "Keyword"'
+      );
+  });
 });

--- a/api/tests/file-upload.test.js
+++ b/api/tests/file-upload.test.js
@@ -9,8 +9,6 @@ import fileService from '../modules/file/file.service.js';
 describe('extractKeywordsFromCSV Tests', function () {
   let __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-  beforeEach(function () {});
-
   it('should handle files with less than 100 keywords', async function () {
     const filePath = path.join(__dirname, 'fixtures', 'csv', 'keywords_10.csv');
     const result = await fileService.extractKeywordsFromCSV({ filePath, userId: 1, fileId: 1 });

--- a/api/tests/fixtures/csv/keywords_wrong_header.csv
+++ b/api/tests/fixtures/csv/keywords_wrong_header.csv
@@ -1,0 +1,4 @@
+Words
+yoga exercises for beginners	
+home gardening tips	
+best books to read in 2023


### PR DESCRIPTION
1. Throw meaningful error, when there are no keywords in uploaded file(due to header mismatch or other reasons)
2. Tests for the validation

<img width="657" src="https://github.com/skrishnan22/google-scraper/assets/15868377/d25bca03-7dbc-4634-9cfd-966b981fa264">
